### PR TITLE
0605_fix_아이템,미사일관련이미지오류수정

### DIFF
--- a/data/Animation.py
+++ b/data/Animation.py
@@ -77,12 +77,12 @@ class DestroyEffectAnim(Animation):
 class BombAnim(Animation):
     # 폭탄 아이템 애니메이션 객체 
     def __init__(self):
-        super().__init__(Default.item.value["bomb"]["frames"], Default.item.value["size"])
+        super().__init__(Default.item.value["bomb"]["frames"], Default.item.value["size3"])
 
 class PowerupAnim(Animation):
     # 파워업 아이템 애니메이션 객체 
     def __init__(self):
-        super().__init__(Default.item.value["powerup"]["frames"], Default.item.value["size"])
+        super().__init__(Default.item.value["powerup"]["frames"], Default.item.value["size2"])
 
 class SpeedupAnim(Animation):
     # 스피드업 아이템 애니메이션 객체 

--- a/data/Defs.py
+++ b/data/Defs.py
@@ -165,8 +165,16 @@ class Default(enum.Enum):
     item = {
         "duration":10.0,
         "size":{
-            "x":55, 
-            "y":30
+            "x":45, 
+            "y":45
+        },
+        "size2":{
+            "x":70,
+            "y":35
+        },
+        "size3":{
+            "x":80,
+            "y":33
         },
         "sound": "./Sound/Item/speedup.wav",
         "velocity":5,

--- a/data/characterdata.json
+++ b/data/characterdata.json
@@ -6,8 +6,8 @@
             "velocity": 11,
             "missile_img": "./Image/Weapon/worm.png",
             "missile_size": {
-                "x": 50,
-                "y": 50
+                "x": 35,
+                "y": 55
             },
             "missile_sfx": "./Sound/Weapon/heavy_missile.wav",
             "missile_power": 180,
@@ -20,8 +20,8 @@
             "velocity": 13,
             "missile_img": "./Image/Weapon/carrot.png",
             "missile_size": {
-                "x": 40,
-                "y": 40
+                "x": 35,
+                "y": 55
             },
             "missile_sfx": "./Sound/Weapon/heavy_missile.wav",
             "missile_power": 330,
@@ -32,10 +32,10 @@
             "name": "Haengal",
             "img_path": "./Image/catthema/cat3_back.png",
             "velocity": 13,
-            "missile_img": "./Image/MISSILE_2.png",
+            "missile_img": "./Image/Weapon/carrot.png",
             "missile_size": {
-                "x": 50,
-                "y": 70
+                "x": 35,
+                "y": 55
             },
             "missile_sfx": "./Sound/Weapon/heavy_missile.wav",
             "missile_power": 200,
@@ -46,10 +46,10 @@
             "name": "Kongchi",
             "img_path": "./Image/catthema/cat4_back.png",
             "velocity": 17,
-            "missile_img": "./Image/MISSILE_2.png",
+            "missile_img": "./Image/Weapon/carrot.png",
             "missile_size": {
-                "x": 50,
-                "y": 70
+                "x": 35,
+                "y": 55
             },
             "missile_sfx": "./Sound/Weapon/heavy_missile.wav",
             "missile_power": 450,


### PR DESCRIPTION
1. 아이템별로 사이즈 다르게 설정
2. 이전파일삭제로 인해 carrot-미사일이 적용 안되어 있었던 캐릭터가 있어서 미사일 이미지 수정